### PR TITLE
feat: mvc + webflux sse 추가

### DIFF
--- a/reactor/user/build.gradle
+++ b/reactor/user/build.gradle
@@ -16,6 +16,9 @@ dependencies {
     implementation 'io.projectreactor:reactor-core'
     testImplementation 'io.projectreactor:reactor-test'
 
+    // Redis Pub/Sub
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
     runtimeOnly 'org.mariadb:r2dbc-mariadb'
     testRuntimeOnly 'io.r2dbc:r2dbc-h2'

--- a/reactor/user/http/test.http
+++ b/reactor/user/http/test.http
@@ -19,3 +19,12 @@ GET localhost:8082/test/time
 
 ### weather
 GET localhost:8082/test/weather
+
+###
+POST localhost:8082/messages
+Content-Type: application/json
+
+{
+  "id": "test",
+  "message": "test"
+}

--- a/reactor/user/src/main/java/com/sample/UserReactorApplication.java
+++ b/reactor/user/src/main/java/com/sample/UserReactorApplication.java
@@ -25,8 +25,6 @@ import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
  * @since 1.0
  */
 @SpringBootApplication
-@EnableR2dbcRepositories
-@EnableR2dbcAuditing
 public class UserReactorApplication {
 
   /**

--- a/reactor/user/src/main/java/com/sample/config/R2dbcConfig.java
+++ b/reactor/user/src/main/java/com/sample/config/R2dbcConfig.java
@@ -1,0 +1,29 @@
+/*
+ * Created by Hochan Son on 2025. 6. 23.
+ * As part of
+ *
+ * Copyright (C)  () - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ * Written by Backend Team <hc.son9@google.com>, 2025. 6. 23.
+ */
+
+package com.sample.config;
+
+import org.springframework.data.r2dbc.config.EnableR2dbcAuditing;
+import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
+
+/**
+ * create on 2025. 6. 23. create by IntelliJ IDEA. create by IntelliJ IDEA.
+ *
+ * <p>R2DBC 관련 Config. </p>
+ *
+ * @author Hochan Son
+ * @version 1.0
+ * @since 1.0
+ */
+@EnableR2dbcRepositories
+@EnableR2dbcAuditing
+public class R2dbcConfig {
+
+}

--- a/reactor/user/src/main/java/com/sample/config/RedisConfig.java
+++ b/reactor/user/src/main/java/com/sample/config/RedisConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Created by Hochan Son on 2025. 6. 23.
+ * As part of
+ *
+ * Copyright (C)  () - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ * Written by Backend Team <hc.son9@google.com>, 2025. 6. 23.
+ */
+
+package com.sample.config;
+
+import com.sample.message.entity.MessageChannel;
+import com.sample.publisher.RedisMessagePublisher;
+import com.sample.subscriber.MessageSubscriber;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+/**
+ * create on 2025. 6. 23. create by IntelliJ IDEA. create by IntelliJ IDEA.
+ *
+ * <p>Redis 관련. </p>
+ *
+ * @author Hochan Son
+ * @version 1.0
+ * @since 1.0
+ */
+@Configuration
+public class RedisConfig {
+
+  /**
+   * 구독 관련 Container.
+   *
+   * @param connectionFactory 커넥션 정보
+   * @param subscriber        구독 정보
+   * @return 응답.
+   */
+  @Bean
+  public RedisMessageListenerContainer container(RedisConnectionFactory connectionFactory,
+      MessageSubscriber subscriber) {
+    RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+    container.setConnectionFactory(connectionFactory);
+    container.addMessageListener(subscriber, new ChannelTopic(MessageChannel.DEFAULT.getName()));
+    return container;
+  }
+
+  /**
+   * 레디스 설정 정보.
+   *
+   * @param connectionFactory 커넥션정보
+   * @return RedisTemplate
+   */
+  @Bean
+  public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+    RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(connectionFactory);
+    redisTemplate.setKeySerializer(new StringRedisSerializer());
+    redisTemplate.setValueSerializer(new StringRedisSerializer());
+    return redisTemplate;
+  }
+}

--- a/reactor/user/src/main/java/com/sample/controller/MessageController.java
+++ b/reactor/user/src/main/java/com/sample/controller/MessageController.java
@@ -11,10 +11,9 @@
 package com.sample.controller;
 
 import com.sample.message.dto.MessageDto;
-import com.sample.message.publisher.MessagePublisher;
-import com.sample.publisher.RedisMessagePublisher;
-import com.sample.service.EmitterService;
+import com.sample.service.MessageService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -23,12 +22,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
  * create on 2025. 6. 23. create by IntelliJ IDEA. create by IntelliJ IDEA.
  *
- * <p>메시지 관련 Test. </p>
+ * <p>Message 관련 Controller. </p>
  *
  * @author Hochan Son
  * @version 1.0
@@ -37,29 +37,29 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RestController
 @RequiredArgsConstructor
 public class MessageController {
-  private final EmitterService service;
-  private final MessagePublisher publisher;
+
+  private final MessageService messageService;
 
   /**
-   * SSe Message 구독.
+   * SSE 연결.
    *
-   * @param userId 구독할 id
-   * @return 응답
+   * @param userId userId
+   * @return Message 정보
    */
   @GetMapping(value = "/streaming-messages/{userId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-  public SseEmitter streamingMessages(@PathVariable String userId) {
-    return service.subscribe(userId);
+  public Flux<MessageDto> streamingMessages(@PathVariable String userId) {
+    return messageService.subscribe(userId);
   }
 
   /**
    * 메시지 발행.
    *
-   * @param dto 발행할 Dto
-   * @return 으답
+   * @param messageDto 메시지 정보
+   * @return 응답
    */
   @PostMapping("/messages")
-  public ResponseEntity<Void> publishMessage(@RequestBody MessageDto dto) {
-    publisher.publish(dto);
-    return ResponseEntity.ok().build();
+  public Mono<ResponseEntity<Void>> publish(@RequestBody MessageDto messageDto) {
+    messageService.publish(messageDto);
+    return Mono.just(ResponseEntity.ok().build());
   }
 }

--- a/reactor/user/src/main/java/com/sample/controller/MessageController.java
+++ b/reactor/user/src/main/java/com/sample/controller/MessageController.java
@@ -59,7 +59,8 @@ public class MessageController {
    */
   @PostMapping("/messages")
   public Mono<ResponseEntity<Void>> publish(@RequestBody MessageDto messageDto) {
-    messageService.publish(messageDto);
-    return Mono.just(ResponseEntity.ok().build());
+
+    return messageService.publish(messageDto)
+        .then(Mono.just(ResponseEntity.ok().build()));
   }
 }

--- a/reactor/user/src/main/java/com/sample/controller/UserController.java
+++ b/reactor/user/src/main/java/com/sample/controller/UserController.java
@@ -12,6 +12,7 @@ package com.sample.controller;
 
 import com.sample.dto.UserDto;
 import com.sample.service.UserService;
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -46,7 +47,7 @@ public class UserController {
   @PostMapping
   public Mono<ResponseEntity<UserDto.Response>> createUser(@RequestBody UserDto.Create dto) {
     Mono<UserDto.Response> user = userService.create(dto.getName());
-    return user.map(u -> ResponseEntity.ok().body(u));
+    return user.map(u -> ResponseEntity.created(URI.create("/users/" + u.getId())).body(u));
   }
 
   /**

--- a/reactor/user/src/main/java/com/sample/publisher/RedisMessagePublisher.java
+++ b/reactor/user/src/main/java/com/sample/publisher/RedisMessagePublisher.java
@@ -16,6 +16,7 @@ import com.sample.message.dto.MessageDto;
 import com.sample.message.entity.MessageChannel;
 import com.sample.message.publisher.MessagePublisher;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
@@ -30,6 +31,7 @@ import org.springframework.stereotype.Component;
  */
 @RequiredArgsConstructor
 @Component
+@Slf4j
 public class RedisMessagePublisher implements MessagePublisher {
 
   private final RedisTemplate<String, String> redisTemplate;

--- a/reactor/user/src/main/java/com/sample/publisher/RedisMessagePublisher.java
+++ b/reactor/user/src/main/java/com/sample/publisher/RedisMessagePublisher.java
@@ -1,0 +1,47 @@
+/*
+ * Created by Hochan Son on 2025. 6. 23.
+ * As part of
+ *
+ * Copyright (C)  () - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ * Written by Backend Team <hc.son9@google.com>, 2025. 6. 23.
+ */
+
+package com.sample.publisher;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sample.message.dto.MessageDto;
+import com.sample.message.entity.MessageChannel;
+import com.sample.message.publisher.MessagePublisher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * create on 2025. 6. 23. create by IntelliJ IDEA. create by IntelliJ IDEA.
+ *
+ * <p>메시지 발행. </p>
+ *
+ * @author Hochan Son
+ * @version 1.0
+ * @since 1.0
+ */
+@RequiredArgsConstructor
+@Component
+public class RedisMessagePublisher implements MessagePublisher {
+
+  private final RedisTemplate<String, String> redisTemplate;
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void publish(MessageDto message) {
+    try {
+      String json = objectMapper.writeValueAsString(message);
+      redisTemplate.convertAndSend(MessageChannel.DEFAULT.getName(), json);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/reactor/user/src/main/java/com/sample/repository/SinkRepository.java
+++ b/reactor/user/src/main/java/com/sample/repository/SinkRepository.java
@@ -1,0 +1,51 @@
+/*
+ * Created by Hochan Son on 2025. 6. 23.
+ * As part of
+ *
+ * Copyright (C)  () - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ * Written by Backend Team <hc.son9@google.com>, 2025. 6. 23.
+ */
+
+package com.sample.repository;
+
+import com.sample.message.dto.MessageDto;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Sinks;
+
+/**
+ * create on 2025. 6. 23. create by IntelliJ IDEA. create by IntelliJ IDEA.
+ *
+ * <p>Sink 관련 Repository. </p>
+ *
+ * @author Hochan Son
+ * @version 1.0
+ * @since 1.0
+ */
+@Repository
+public class SinkRepository {
+
+  private final Map<String, Sinks.Many<MessageDto>> sinks = new ConcurrentHashMap<>();
+
+  /**
+   * 획득.
+   *
+   * @param userId userId.
+   * @return Sink 정보
+   */
+  public Sinks.Many<MessageDto> get(String userId) {
+    return sinks.computeIfAbsent(userId, k -> Sinks.many().multicast().onBackpressureBuffer());
+  }
+
+  /**
+   * 삭제.
+   *
+   * @param userId userId
+   */
+  public void remove(String userId) {
+    sinks.remove(userId);
+  }
+}

--- a/reactor/user/src/main/java/com/sample/service/MessageService.java
+++ b/reactor/user/src/main/java/com/sample/service/MessageService.java
@@ -20,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
  * create on 2025. 6. 23. create by IntelliJ IDEA. create by IntelliJ IDEA.
@@ -54,8 +55,8 @@ public class MessageService {
    *
    * @param dto 발행 메시지.
    */
-  public void publish(MessageDto dto) {
-    redisMessagePublisher.publish(dto);
+  public Mono<Void> publish(MessageDto dto) {
+    return Mono.fromRunnable(() -> redisMessagePublisher.publish(dto));
   }
 
 }

--- a/reactor/user/src/main/java/com/sample/service/MessageService.java
+++ b/reactor/user/src/main/java/com/sample/service/MessageService.java
@@ -58,5 +58,4 @@ public class MessageService {
   public Mono<Void> publish(MessageDto dto) {
     return Mono.fromRunnable(() -> redisMessagePublisher.publish(dto));
   }
-
 }

--- a/reactor/user/src/main/java/com/sample/service/MessageService.java
+++ b/reactor/user/src/main/java/com/sample/service/MessageService.java
@@ -1,0 +1,61 @@
+/*
+ * Created by Hochan Son on 2025. 6. 23.
+ * As part of
+ *
+ * Copyright (C)  () - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ * Written by Backend Team <hc.son9@google.com>, 2025. 6. 23.
+ */
+
+package com.sample.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sample.message.dto.MessageDto;
+import com.sample.message.entity.MessageChannel;
+import com.sample.publisher.RedisMessagePublisher;
+import com.sample.repository.SinkRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+
+/**
+ * create on 2025. 6. 23. create by IntelliJ IDEA. create by IntelliJ IDEA.
+ *
+ * <p>Message 관련 Service. </p>
+ *
+ * @author Hochan Son
+ * @version 1.0
+ * @since 1.0
+ */
+@Service
+@RequiredArgsConstructor
+public class MessageService {
+
+  private final SinkRepository sinkRepository;
+  private final RedisMessagePublisher redisMessagePublisher;
+
+  /**
+   * 구독.
+   *
+   * @param userId userId
+   * @return 메시지
+   */
+  public Flux<MessageDto> subscribe(String userId) {
+    return sinkRepository.get(userId)
+        .asFlux()
+        .doFinally(sink -> sinkRepository.remove(userId));
+  }
+
+  /**
+   * 발행.
+   *
+   * @param dto 발행 메시지.
+   */
+  public void publish(MessageDto dto) {
+    redisMessagePublisher.publish(dto);
+  }
+
+}

--- a/reactor/user/src/main/java/com/sample/subscriber/MessageSubscriber.java
+++ b/reactor/user/src/main/java/com/sample/subscriber/MessageSubscriber.java
@@ -1,0 +1,49 @@
+/*
+ * Created by Hochan Son on 2025. 6. 23.
+ * As part of
+ *
+ * Copyright (C)  () - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ * Written by Backend Team <hc.son9@google.com>, 2025. 6. 23.
+ */
+
+package com.sample.subscriber;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sample.message.dto.MessageDto;
+import com.sample.repository.SinkRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * create on 2025. 6. 23. create by IntelliJ IDEA. create by IntelliJ IDEA.
+ *
+ * <p>메시지 구독정보. </p>
+ *
+ * @author Hochan Son
+ * @version 1.0
+ * @since 1.0
+ */
+@Component
+@RequiredArgsConstructor
+public class MessageSubscriber implements MessageListener {
+  private final ObjectMapper objectMapper;
+  private final SinkRepository sinkRepository;
+
+  @Override
+  public void onMessage(Message message, byte[] pattern) {
+    try {
+      String json = new String(message.getBody());
+      MessageDto dto = objectMapper.readValue(json, MessageDto.class);
+      sinkRepository.get(dto.getId()).tryEmitNext(dto);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/reactor/user/src/main/resources/application.yml
+++ b/reactor/user/src/main/resources/application.yml
@@ -16,6 +16,11 @@ spring:
 server:
   port: 8082
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
 api:
   url:
     wallet: http://localhost:8083

--- a/reactor/user/src/main/resources/application.yml
+++ b/reactor/user/src/main/resources/application.yml
@@ -13,13 +13,12 @@ spring:
     init:
       schema-locations: classpath:db/mysql/schema.sql
       mode: always
-server:
-  port: 8082
-
   data:
     redis:
       host: localhost
       port: 6379
+server:
+  port: 8082
 
 api:
   url:

--- a/reactor/user/src/main/resources/static/index.html
+++ b/reactor/user/src/main/resources/static/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>SSE 메시지 스트리밍 테스트</title>
+</head>
+<body>
+<h1>Redis Pub/Sub SSE 테스트</h1>
+<div id="messages"></div>
+
+<script>
+  const eventSource = new EventSource('/streaming-messages/test');
+
+  eventSource.onmessage = function(event) {
+    const messagesDiv = document.getElementById('messages');
+    messagesDiv.innerHTML += `<p>${event.data}</p>`;
+  };
+
+  eventSource.onerror = function(err) {
+    console.error('EventSource failed:', err);
+    eventSource.close();
+  };
+</script>
+</body>
+</html>

--- a/reactor/user/src/test/java/com/sample/controller/MessageControllerTest.java
+++ b/reactor/user/src/test/java/com/sample/controller/MessageControllerTest.java
@@ -1,0 +1,101 @@
+package com.sample.controller;/*
+ * Created by Hochan Son on 2025. 6. 23.
+ * As part of
+ *
+ * Copyright (C)  () - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ * Written by Backend Team <hc.son9@google.com>, 2025. 6. 23.
+ */
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import com.sample.message.dto.MessageDto;
+import com.sample.service.MessageService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.test.StepVerifier;
+
+/**
+ * create on 2025. 6. 23. create by IntelliJ IDEA. create by IntelliJ IDEA.
+ *
+ * <p>클래스 설명. </p>
+ * <p> {@link } and {@link }관련 클래스 </p>
+ *
+ * @author Hochan Son
+ * @version 1.0
+ * @see
+ * @since 지원하는 자바버전 (ex : 5+ 5이상)
+ */
+@WebFluxTest(controllers = MessageController.class)
+class MessageControllerTest {
+
+  @Autowired
+  private WebTestClient webClient;
+
+  @MockitoBean
+  private MessageService messageService;
+
+  @Test
+  void streamingMessagesSuccess() {
+    //given
+    MessageDto messageDto1 = new MessageDto("user", "message1");
+    MessageDto messageDto2 = new MessageDto("user", "message2");
+
+//    Sinks.Many<MessageDto> sink = Sinks.many().replay().all();
+    when(messageService.subscribe(anyString())).thenReturn(Flux.just(messageDto1, messageDto2));
+
+    // then
+    webClient.get().uri("/streaming-messages/{userId}", messageDto1.getId())
+        .accept(MediaType.TEXT_EVENT_STREAM)
+        .exchange()
+        .expectStatus().isOk()
+        .expectHeader().contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM_VALUE)
+        .returnResult(MessageDto.class)
+        .getResponseBody()
+        .as(StepVerifier::create)
+        .expectNextMatches(response -> response.getMessage().equals(messageDto1.getMessage()))
+        .expectNextMatches(response -> response.getMessage().equals(messageDto2.getMessage()))
+        .thenCancel()
+        .verify();
+  }
+
+  @Test
+  void publishSuccess() {
+    // given
+    MessageDto messageDto = new MessageDto("user", "message1");
+
+    // when
+    when(messageService.publish(any())).thenReturn(Mono.empty());
+
+
+    // then
+    webClient.post().uri("/messages")
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(messageDto)
+        .exchange()
+        .expectStatus().isOk();
+
+    // verify(...)로 실제로 publish()가 호출되었는지 확인.
+    // argThat는 메서드가 호출될 때 전달된 인자가 특정 조건을 만족했는지 확인하는 데 사용하는 Mockito 도구입니다.
+    verify(messageService).publish(argThat(dto -> dto.getMessage().equals("message1")));
+
+    // ArgumentCaptor 사용
+    ArgumentCaptor<MessageDto> captor = ArgumentCaptor.forClass(MessageDto.class);
+    verify(messageService).publish(captor.capture());
+    MessageDto actual = captor.getValue();
+
+    assertThat(actual.getId()).isEqualTo(messageDto.getId());
+    assertThat(actual.getMessage()).isEqualTo(messageDto.getMessage());
+  }
+}

--- a/reactor/user/src/test/java/com/sample/controller/UserControllerTest.java
+++ b/reactor/user/src/test/java/com/sample/controller/UserControllerTest.java
@@ -1,0 +1,103 @@
+package com.sample.controller;/*
+ * Created by Hochan Son on 2025. 6. 23.
+ * As part of
+ *
+ * Copyright (C)  () - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ * Written by Backend Team <hc.son9@google.com>, 2025. 6. 23.
+ */
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import com.sample.dto.UserDto;
+import com.sample.dto.UserDto.Create;
+import com.sample.dto.UserDto.Response;
+import com.sample.service.UserService;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.reactive.server.WebTestClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * create on 2025. 6. 23. create by IntelliJ IDEA. create by IntelliJ IDEA.
+ *
+ * <p>클래스 설명. </p>
+ * <p> {@link } and {@link }관련 클래스 </p>
+ *
+ * @author Hochan Son
+ * @version 1.0
+ * @see
+ * @since 지원하는 자바버전 (ex : 5+ 5이상)
+ */
+@WebFluxTest(UserController.class)
+class UserControllerTest {
+
+  @Autowired
+  private WebTestClient webClient;
+
+  @MockitoBean
+  private UserService userService;
+
+  private String baseUrl = "/users";
+
+  @Test
+  void createUserSuccess() {
+    // given
+    UserDto.Create create = new Create("user");
+    UserDto.Response response = new Response(UUID.randomUUID(), create.getName(), 1L,
+        LocalDateTime.now(), LocalDateTime.now());
+
+    // when
+    when(userService.create(any())).thenReturn(Mono.just(response));
+
+
+    // then
+    webClient.post().uri(baseUrl)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(create)
+        .exchange()
+        .expectStatus().isCreated()
+        .returnResult(UserDto.Response.class)
+        .getResponseBody()
+        .as(StepVerifier::create)
+        .expectNextMatches(dto -> dto.getName().equals(create.getName()))
+        .verifyComplete();
+  }
+
+  @Test
+  void updateUserSuccess() {
+    // given
+    UserDto.Create create = new Create("user");
+    UserDto.Response response = new Response(UUID.randomUUID(), create.getName(), 1L,
+        LocalDateTime.now(), LocalDateTime.now());
+
+    // when
+    when(userService.transactionTest(any())).thenReturn(Mono.just(response));
+
+    // then
+    webClient.put()
+        .uri(baseUrl)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(create)
+        .exchange()
+        .expectStatus().isOk()
+        .returnResult(UserDto.Response.class)
+        .getResponseBody()
+        .as(StepVerifier::create)
+        .expectNextMatches(dto -> dto.getName().equals(create.getName()))
+        .verifyComplete();
+  }
+}

--- a/reactor/user/src/test/java/com/sample/service/MessageServiceTest.java
+++ b/reactor/user/src/test/java/com/sample/service/MessageServiceTest.java
@@ -1,0 +1,89 @@
+package com.sample.service;/*
+ * Created by Hochan Son on 2025. 6. 23.
+ * As part of
+ *
+ * Copyright (C)  () - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ * Written by Backend Team <hc.son9@google.com>, 2025. 6. 23.
+ */
+
+import static org.assertj.core.api.Assertions.setAllowComparingPrivateFields;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import com.sample.message.dto.MessageDto;
+import com.sample.publisher.RedisMessagePublisher;
+import com.sample.repository.SinkRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.test.StepVerifier;
+
+/**
+ * create on 2025. 6. 23. create by IntelliJ IDEA. create by IntelliJ IDEA.
+ *
+ * <p>클래스 설명. </p>
+ * <p> {@link } and {@link }관련 클래스 </p>
+ *
+ * @author Hochan Son
+ * @version 1.0
+ * @see
+ * @since 지원하는 자바버전 (ex : 5+ 5이상)
+ */
+@ExtendWith(MockitoExtension.class)
+class MessageServiceTest {
+
+  @InjectMocks
+  private MessageService messageService;
+
+  @Mock
+  private SinkRepository sinkRepository;
+
+  @Mock
+  private RedisMessagePublisher redisMessagePublisher;
+
+
+  @Test
+  void subscribeSuccess() {
+    String userId = "user";
+    MessageDto messageDto = new MessageDto(userId, "message");
+
+    Sinks.Many<MessageDto> sinks = Sinks.many().unicast().onBackpressureBuffer();
+    sinks.tryEmitNext(messageDto);
+
+    when(sinkRepository.get(userId)).thenReturn(sinks);
+
+    Flux<MessageDto> result = messageService.subscribe(userId);
+
+    StepVerifier.create(result)
+        .expectNextMatches(r -> r.getMessage().equals(messageDto.getMessage()))
+        .thenCancel()
+        .verify();
+
+    verify(sinkRepository).remove(userId);
+
+  }
+
+  @Test
+  void publish() {
+    String userId = "user";
+    MessageDto messageDto = new MessageDto(userId, "message");
+
+    Mono<Void> result = messageService.publish(messageDto);
+
+    StepVerifier.create(result)
+        .verifyComplete();
+
+    verify(redisMessagePublisher).publish(messageDto);
+    verify(redisMessagePublisher).publish(argThat(dto -> dto.getMessage().equals(messageDto.getMessage())));
+  }
+}

--- a/reactor/user/src/test/java/com/sample/service/UserServiceTest.java
+++ b/reactor/user/src/test/java/com/sample/service/UserServiceTest.java
@@ -1,0 +1,136 @@
+package com.sample.service;/*
+ * Created by Hochan Son on 2025. 6. 23.
+ * As part of
+ *
+ * Copyright (C)  () - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ * Written by Backend Team <hc.son9@google.com>, 2025. 6. 23.
+ */
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import com.sample.dto.UserDto;
+import com.sample.entity.User;
+import com.sample.repository.UserRepository;
+import com.sample.wallet.dto.WalletDto;
+import com.sample.wallet.dto.WalletDto.Response;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+/**
+ * create on 2025. 6. 23. create by IntelliJ IDEA. create by IntelliJ IDEA.
+ *
+ * <p>클래스 설명. </p>
+ * <p> {@link } and {@link }관련 클래스 </p>
+ *
+ * @author Hochan Son
+ * @version 1.0
+ * @see
+ * @since 지원하는 자바버전 (ex : 5+ 5이상)
+ */
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+  @InjectMocks
+  private UserService userService;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Mock
+  private WebClient walletWebClient;
+
+  @Mock
+  private WebClient.RequestBodyUriSpec requestBodyUriSpec;
+
+  @Mock
+  private WebClient.RequestBodySpec requestBodySpec;
+
+  @Mock
+  private WebClient.RequestHeadersSpec requestHeadersSpec;
+
+  @Mock
+  private WebClient.ResponseSpec responseSpec;
+
+  @Test
+  void createSuccess() {
+    //given
+    String name = "user";
+    UUID uuid = UUID.randomUUID();
+    User user = new User(uuid, name);
+
+    WalletDto.Response walletResponse = new Response(1L, uuid, BigDecimal.ZERO, LocalDateTime.now(), LocalDateTime.now());
+    UserDto.Response response = new UserDto.Response(uuid, name, walletResponse.getId(), user.getCreatedAt(), user.getModifiedAt());
+
+    // when
+    when(userRepository.save(any())).thenReturn(Mono.just(user));
+    when(walletWebClient.post()).thenReturn(requestBodyUriSpec);
+    when(requestBodyUriSpec.uri("/wallets")).thenReturn(requestBodySpec);
+    when(requestBodySpec.bodyValue(any())).thenReturn(requestHeadersSpec);
+    when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+    when(responseSpec.bodyToMono(WalletDto.Response.class)).thenReturn(Mono.just(walletResponse));
+
+    Mono<UserDto.Response> result = userService.create(name);
+
+    // then
+    StepVerifier.create(result)
+        .expectNextMatches(res ->
+            res.getId().equals(response.getId()) &&
+                res.getName().equals(response.getName()) &&
+                res.getWalletId().equals(response.getWalletId()))
+        .verifyComplete();
+
+    verify(userRepository).save(any());
+    verify(walletWebClient).post();
+  }
+
+  @Test
+  void transactionTest() {
+    // given
+    String name = "name";
+    UUID userId = UUID.randomUUID();
+    User existingUser = new User(userId, name);
+
+    // 수정된 이름
+    User updatedUser = new User(userId, name + " 1");
+
+    WalletDto.Response walletResponse = new Response(1L, userId, BigDecimal.ZERO, LocalDateTime.now(), LocalDateTime.now());
+
+    when(userRepository.findByName(name)).thenReturn(Mono.just(existingUser));
+    when(userRepository.update(any())).thenReturn(Mono.just(updatedUser));
+
+    // WebClient mocking
+    when(walletWebClient.post()).thenReturn(requestBodyUriSpec);
+    when(requestBodyUriSpec.uri("/wallets")).thenReturn(requestBodySpec);
+    when(requestBodySpec.bodyValue(any())).thenReturn(requestHeadersSpec);
+    when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+    when(responseSpec.bodyToMono(WalletDto.Response.class)).thenReturn(Mono.just(walletResponse));
+
+    // when
+    Mono<UserDto.Response> result = userService.transactionTest(name);
+
+    // then
+    StepVerifier.create(result)
+        .expectNextMatches(res ->
+            res.getId().equals(userId) &&
+                res.getName().equals(name + " 1") &&
+                res.getWalletId().equals(walletResponse.getId()))
+        .verifyComplete();
+
+    verify(userRepository).findByName(name);
+    verify(userRepository).update(any());
+    verify(walletWebClient).post();
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 실시간 메시지 스트리밍(Server-Sent Events, SSE) 엔드포인트가 추가되어 사용자가 실시간으로 메시지를 받을 수 있습니다.
    - 메시지 발송을 위한 REST API가 추가되었습니다.
    - Redis Pub/Sub 연동이 도입되어 메시지의 실시간 전송 및 구독이 가능합니다.
    - 메시지 스트리밍 테스트용 웹 페이지가 추가되었습니다.

- **설정**
    - Redis 연결 설정이 추가되었습니다.

- **테스트**
    - 메시지 발송 및 스트리밍 관련 HTTP 테스트와 단위 테스트가 추가되었습니다.
    - 사용자 생성 및 업데이트 관련 컨트롤러 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->